### PR TITLE
Auto registration of Cells, Headers and Footer

### DIFF
--- a/TableSectionModules.podspec
+++ b/TableSectionModules.podspec
@@ -8,7 +8,7 @@ s.summary = "TableSectionModules lets you to reuse table section modules in diff
 s.requires_arc = true
 
 # 2
-s.version = "1.0.5"
+s.version = "1.0.6"
 
 # 3
 s.license = { :type => "MIT", :file => "LICENSE" }

--- a/TableSectionModules.podspec
+++ b/TableSectionModules.podspec
@@ -8,7 +8,7 @@ s.summary = "TableSectionModules lets you to reuse table section modules in diff
 s.requires_arc = true
 
 # 2
-s.version = "1.0.4"
+s.version = "1.0.5"
 
 # 3
 s.license = { :type => "MIT", :file => "LICENSE" }

--- a/TableSectionModules/1.0.5/TableSectionModules.podspec
+++ b/TableSectionModules/1.0.5/TableSectionModules.podspec
@@ -1,0 +1,34 @@
+Pod::Spec.new do |s|
+
+# 1
+s.platform = :ios
+s.ios.deployment_target = '8.0'
+s.name = "TableSectionModules"
+s.summary = "TableSectionModules lets you to reuse table section modules in different tablevies"
+s.requires_arc = true
+
+# 2
+s.version = "1.0.5"
+
+# 3
+s.license = { :type => "MIT", :file => "LICENSE" }
+
+# 4 - Replace with your name and e-mail address
+s.author = { "Carlos Jimenez Galindo" => "jimenezgalindocarlos@gmail.com" }
+
+# 5 - Replace this URL with your own Github page's URL (from the address bar)
+s.homepage = "https://github.com/cjg552/TableSectionModules"
+
+# 6 - Replace this URL with your own Git URL from "Quick Setup"
+s.source = { :git => "https://github.com/cjg552/TableSectionModules.git", :tag => "#{s.version}"}
+
+# 7
+s.framework = "UIKit"
+s.framework = "Foundation"
+
+# 8
+s.source_files = "TableSectionModules/**/*.{swift}"
+
+# 9
+# s.resources = "TableSectionModules/**/*.{png,jpeg,jpg,storyboard,xib}"
+end

--- a/TableSectionModules/1.0.6/TableSectionModules.podspec
+++ b/TableSectionModules/1.0.6/TableSectionModules.podspec
@@ -1,0 +1,34 @@
+Pod::Spec.new do |s|
+
+# 1
+s.platform = :ios
+s.ios.deployment_target = '8.0'
+s.name = "TableSectionModules"
+s.summary = "TableSectionModules lets you to reuse table section modules in different tablevies"
+s.requires_arc = true
+
+# 2
+s.version = "1.0.6"
+
+# 3
+s.license = { :type => "MIT", :file => "LICENSE" }
+
+# 4 - Replace with your name and e-mail address
+s.author = { "Carlos Jimenez Galindo" => "jimenezgalindocarlos@gmail.com" }
+
+# 5 - Replace this URL with your own Github page's URL (from the address bar)
+s.homepage = "https://github.com/cjg552/TableSectionModules"
+
+# 6 - Replace this URL with your own Git URL from "Quick Setup"
+s.source = { :git => "https://github.com/cjg552/TableSectionModules.git", :tag => "#{s.version}"}
+
+# 7
+s.framework = "UIKit"
+s.framework = "Foundation"
+
+# 8
+s.source_files = "TableSectionModules/**/*.{swift}"
+
+# 9
+# s.resources = "TableSectionModules/**/*.{png,jpeg,jpg,storyboard,xib}"
+end

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -24,6 +24,7 @@ public class BaseViewController: UIViewController {
     }
     
     public func configureTableSectionModules() {
+        self.tableSectionModules = []
     }
     
 }

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -12,7 +12,7 @@ import Foundation
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
-    private(set) var tableSectionModules:[TableSectionModule] = []
+    private(set) public var tableSectionModules:[TableSectionModule] = []
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -12,7 +12,7 @@ import Foundation
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
-    private(set) public var tableSectionModules:[TableSectionModule] = []
+    private var tableSectionModules:[TableSectionModule] = []
     
     
     public override func viewDidLoad() {

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -12,8 +12,7 @@ import Foundation
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
-    private var tableSectionModules:[TableSectionModule] = []
-    
+    private(set) var tableSectionModules:[TableSectionModule] = []
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -12,7 +12,7 @@ import Foundation
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
-    private(set) public var tableSectionModules:[TableSectionModule]?
+    private(set) public var tableSectionModules:[TableSectionModule] = []
     
     
     public override func viewDidLoad() {
@@ -25,7 +25,6 @@ public class BaseViewController: UIViewController {
     }
     
     public func configureTableSectionModules() {
-        self.tableSectionModules = []
     }
     
 }
@@ -33,79 +32,83 @@ public class BaseViewController: UIViewController {
 extension BaseViewController: TableSectionModuleSectionSource {
     public func appendModule(module: TableSectionModule) {
         module.sectionSource = self;
-        self.tableSectionModules?.append(module)
+        self.tableSectionModules.append(module)
     }
     
     public func insertModule(module: TableSectionModule, atIndex: Int) {
         module.sectionSource = self;
-        self.tableSectionModules?.insert(module, atIndex: atIndex)
+        self.tableSectionModules.insert(module, atIndex: atIndex)
     }
     
     public func removeAllModules() {
-        self.tableSectionModules?.removeAll()
+        self.tableSectionModules.removeAll()
     }
     
     public func removeModuleAtIndex(atIndex: Int) {
-        self.tableSectionModules?.removeAtIndex(atIndex)
+        self.tableSectionModules.removeAtIndex(atIndex)
     }
     
     public func removeFirstModule() {
-        self.tableSectionModules?.removeFirst()
+        self.tableSectionModules.removeFirst()
     }
     
     public func removeLastModule() {
-        self.tableSectionModules?.removeLast()
+        self.tableSectionModules.removeLast()
+    }
+    
+    public func replaceModuleAtSection(section: NSInteger, withModule module: TableSectionModule) {
+        self.tableSectionModules[section] = module
     }
     
     public func sectionForModule(module: TableSectionModule) -> NSInteger {
-        return (self.tableSectionModules?.indexOf(module))!
+        return (self.tableSectionModules.indexOf(module))!
     }
 }
 
 extension BaseViewController: UITableViewDelegate, UITableViewDataSource {
     public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return self.tableSectionModules![section].heightForFooter()
+        return self.tableSectionModules[section].heightForFooter()
     }
     
     public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return self.tableSectionModules![section].viewForFooter()
+        return self.tableSectionModules[section].viewForFooter()
     }
     
     public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return self.tableSectionModules![section].heightForHeader()
+        return self.tableSectionModules[section].heightForHeader()
     }
     
     public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return self.tableSectionModules![section].viewForHeader()
+        return self.tableSectionModules[section].viewForHeader()
     }
     
     public func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return self.tableSectionModules!.count
+        return self.tableSectionModules.count
     }
     
     public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.tableSectionModules![section].numberOfRows()
+        return self.tableSectionModules[section].numberOfRows()
     }
     
     public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return self.tableSectionModules![indexPath.section].heightForRow(indexPath.row)
+        return self.tableSectionModules[indexPath.section].heightForRow(indexPath.row)
     }
     
     public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        return self.tableSectionModules![indexPath.section].cellForRow(indexPath.row)
+        return self.tableSectionModules[indexPath.section].cellForRow(indexPath.row)
     }
     
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: true)
-        self.tableSectionModules![indexPath.section].didSelectRow(indexPath.row)
+        self.tableSectionModules[indexPath.section].didSelectRow(indexPath.row)
     }
     
     public func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return self.tableSectionModules![indexPath.section].canEditRow(indexPath.row)
+        return self.tableSectionModules[indexPath.section].canEditRow(indexPath.row)
     }
     
     public func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
-        self.tableSectionModules![indexPath.section].commitEditingStyle(editingStyle, forRow: indexPath.row)
+        self.tableSectionModules[indexPath.section].commitEditingStyle(editingStyle, forRow: indexPath.row)
     }
     
 }

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -56,6 +56,7 @@ extension BaseViewController: TableSectionModuleSectionSource {
     }
     
     public func replaceModuleAtSection(section: NSInteger, withModule module: TableSectionModule) {
+        module.sectionSource = self
         self.tableSectionModules[section] = module
     }
     

--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Foundation
 
+// MARK: - BaseViewController's cycle of Life
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
@@ -29,6 +30,7 @@ public class BaseViewController: UIViewController {
     
 }
 
+// MARK: - TableSectionModuleSectionSource
 extension BaseViewController: TableSectionModuleSectionSource {
     public func appendModule(module: TableSectionModule) {
         module.sectionSource = self;
@@ -66,6 +68,7 @@ extension BaseViewController: TableSectionModuleSectionSource {
     }
 }
 
+// MARK: - UITableViewDelegate, UITableViewDataSource
 extension BaseViewController: UITableViewDelegate, UITableViewDataSource {
     public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return self.tableSectionModules[section].heightForFooter()

--- a/TableSectionModules/TableSectionModule.swift
+++ b/TableSectionModules/TableSectionModule.swift
@@ -35,7 +35,7 @@ public class TableSectionModule: NSObject {
     }
     
     public func registerViews() {
-        
+        self.autoRegisterViews()
     }
     
     public func viewForHeader() -> UIView {
@@ -77,6 +77,63 @@ public class TableSectionModule: NSObject {
         
     }
     
+}
+
+// MARK: - Autoregistration of Cells, Header and Footer methods
+extension TableSectionModule {
+    private func autoRegisterViews() {
+        self.autoRegisterClassForCells()
+        self.autoRegisterClassForHeadersFooters()
+        self.autoRegisterNibsForCells()
+        self.autoRegisterNibsForHeadersFooters()
+    }
+    
+    //Autoregistrion - Override those methods if the ReuseIdentifier is exactly the same that the Class and the Nib file (if exits)
+    public func registerClassForCells() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerClassForHeadersFooters() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerNibsForCells() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerNibsForHeadersFooters() -> [AnyClass] {
+        return []
+    }
+    
+    private func autoRegisterClassForCells() {
+        for currentClass in self.registerClassForCells() {
+            let identifier = String(currentClass)
+            self.tableView.registerClass(currentClass, forCellReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterClassForHeadersFooters() {
+        for currentClass in self.registerClassForHeadersFooters() {
+            let identifier = String(currentClass)
+            self.tableView.registerClass(currentClass, forHeaderFooterViewReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterNibsForCells() {
+        for currentClass in self.registerNibsForCells() {
+            let identifier = String(currentClass)
+            let nib = UINib.init(nibName: identifier, bundle: nil)
+            self.tableView.registerNib(nib, forCellReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterNibsForHeadersFooters() {
+        for currentClass in self.registerNibsForHeadersFooters() {
+            let identifier = String(currentClass)
+            let nib = UINib.init(nibName: identifier, bundle: nil)
+            self.tableView.registerNib(nib, forHeaderFooterViewReuseIdentifier: identifier)
+        }
+    }
 }
 
 // MARK: - Private Protocol for auto control of the section

--- a/TableSectionModules/TableSectionModule.swift
+++ b/TableSectionModules/TableSectionModule.swift
@@ -79,6 +79,7 @@ public class TableSectionModule: NSObject {
     
 }
 
+// MARK: - Private Protocol for auto control of the section
 public protocol TableSectionModuleSectionSource : NSObjectProtocol {
     func sectionForModule(module: TableSectionModule) -> NSInteger
 }


### PR DESCRIPTION
Usually when in a UITableView when we are registering cells, headers or footers the reuse identifier used to be the same the Name of the Class.

So, with this Pull Request I have added the auto registration of the Classes that fit the previous condition.

Use this feature is not mandatory is something optional. If the module wants to use this feature has to override the functions:

```
registerClassForCells()
registerClassForHeadersFooters()
registerNibsForCells() 
registerNibsForHeadersFooters()
```

Thanks!
