### PR TITLE
Auto registration of Cells, Headers and Footer

### DIFF
--- a/TableSectionModules/BaseViewController.swift
+++ b/TableSectionModules/BaseViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Foundation
 
+// MARK: - BaseViewController's cycle of Life
 public class BaseViewController: UIViewController {
     
     @IBOutlet public var baseTableView:UITableView?
@@ -29,6 +30,7 @@ public class BaseViewController: UIViewController {
     
 }
 
+// MARK: - TableSectionModuleSectionSource
 extension BaseViewController: TableSectionModuleSectionSource {
     public func appendModule(module: TableSectionModule) {
         module.sectionSource = self;
@@ -66,6 +68,7 @@ extension BaseViewController: TableSectionModuleSectionSource {
     }
 }
 
+// MARK: - UITableViewDelegate, UITableViewDataSource
 extension BaseViewController: UITableViewDelegate, UITableViewDataSource {
     public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return self.tableSectionModules[section].heightForFooter()

--- a/TableSectionModules/TableSectionModule.swift
+++ b/TableSectionModules/TableSectionModule.swift
@@ -35,7 +35,7 @@ public class TableSectionModule: NSObject {
     }
     
     public func registerViews() {
-        
+        self.autoRegisterViews()
     }
     
     public func viewForHeader() -> UIView {
@@ -79,6 +79,64 @@ public class TableSectionModule: NSObject {
     
 }
 
+// MARK: - Autoregistration of Cells, Header and Footer methods
+extension TableSectionModule {
+    private func autoRegisterViews() {
+        self.autoRegisterClassForCells()
+        self.autoRegisterClassForHeadersFooters()
+        self.autoRegisterNibsForCells()
+        self.autoRegisterNibsForHeadersFooters()
+    }
+    
+    //Autoregistrion - Override those methods if the ReuseIdentifier is exactly the same that the Class and the Nib file (if exits)
+    public func registerClassForCells() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerClassForHeadersFooters() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerNibsForCells() -> [AnyClass] {
+        return []
+    }
+    
+    public func registerNibsForHeadersFooters() -> [AnyClass] {
+        return []
+    }
+    
+    private func autoRegisterClassForCells() {
+        for currentClass in self.registerClassForCells() {
+            let identifier = String(currentClass)
+            self.tableView.registerClass(currentClass, forCellReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterClassForHeadersFooters() {
+        for currentClass in self.registerClassForHeadersFooters() {
+            let identifier = String(currentClass)
+            self.tableView.registerClass(currentClass, forHeaderFooterViewReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterNibsForCells() {
+        for currentClass in self.registerNibsForCells() {
+            let identifier = String(currentClass)
+            let nib = UINib.init(nibName: identifier, bundle: nil)
+            self.tableView.registerNib(nib, forCellReuseIdentifier: identifier)
+        }
+    }
+    
+    private func autoRegisterNibsForHeadersFooters() {
+        for currentClass in self.registerNibsForHeadersFooters() {
+            let identifier = String(currentClass)
+            let nib = UINib.init(nibName: identifier, bundle: nil)
+            self.tableView.registerNib(nib, forHeaderFooterViewReuseIdentifier: identifier)
+        }
+    }
+}
+
+// MARK: - Private Protocol for auto control of the section
 public protocol TableSectionModuleSectionSource : NSObjectProtocol {
     func sectionForModule(module: TableSectionModule) -> NSInteger
 }


### PR DESCRIPTION
Usually when in a UITableView when we are registering cells, headers or footers the reuse identifier used to be the same the Name of the Class.

So, with this Pull Request I have added the auto registration of the Classes that fit the previous condition.

Use this feature is not mandatory is something optional. If the module wants to use this feature has to override the functions:

```
registerClassForCells()
registerClassForHeadersFooters()
registerNibsForCells() 
registerNibsForHeadersFooters()
```

Thanks!
